### PR TITLE
fixed typo wich prevented spec:yasm tests from working

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ task :default => :spec
 
 namespace :spec do
   RSpec::Core::RakeTask.new(:yasm) do |t|
-    t.pattern    = 'spec/program_spec.rb spec/shellcode_spec.rb'
+    t.pattern    = ['spec/program_spec.rb', 'spec/shellcode_spec.rb']
     t.rspec_opts = '--tag yasm'
   end
 end


### PR DESCRIPTION
This goes with https://github.com/ronin-ruby/ronin-asm/issues/7
